### PR TITLE
Add getTweets and authenticationAdmin feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const bodyParser = require('body-parser')
 const flash = require('connect-flash')
 const session = require('express-session')
 const passport = require('./config/passport')
+const methodOverride = require('method-override')
 
 app.engine('handlebars', exphbs({ defaultLayout: 'main' }))
 app.set('view engine', 'handlebars')
@@ -25,6 +26,8 @@ app.use(passport.initialize())
 app.use(passport.session())
 
 app.use(flash())
+
+app.use(methodOverride('_method'))
 
 app.use((req, res, next) => {
   res.locals.user = helpers.getUser(req)

--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ const session = require('express-session')
 const passport = require('./config/passport')
 const methodOverride = require('method-override')
 
-app.engine('handlebars', exphbs({ defaultLayout: 'main' }))
+app.engine('handlebars', exphbs({ defaultLayout: 'main', helpers: require('./config/handlebars-helpers') }))
 app.set('view engine', 'handlebars')
 
 app.use(bodyParser.urlencoded({ extended: true }))

--- a/config/handlebars-helpers.js
+++ b/config/handlebars-helpers.js
@@ -1,0 +1,8 @@
+module.exports = {
+  ifCond: function (a, b, options) {
+    if (a === b) {
+      return options.fn(this)
+    }
+    return options.inverse(this)
+  }
+}

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -24,6 +24,31 @@ const adminController = {
         return res.render('admin/tweets', { tweets })
       })
   },
+
+  deleteTweet: (req, res) => {
+    // 刪除其他使用者的推文
+    Tweet.findByPk(req.params.id)
+      .then(tweet => {
+        if (!tweet) {
+          req.flash('error_messages', 'Tweet not found!')
+          return res.redirect('back')
+        }
+        if (helpers.getUser(req).role !== 'admin') {
+          req.flash('error_messages', '您無此權限，請重新登入！')
+          return res.redirect('/signin')
+        }
+        tweet.destroy()
+          .then(tweet => {
+            // 刪除該貼文回覆
+            Reply.findAll({ where: { TweetId: req.params.id } })
+              .then(replies => {
+                replies.forEach(reply => reply.destroy())
+              })
+            req.flash('success_messages', '該Tweet已成功刪除')
+            return res.redirect('/admin/tweets')
+          })
+      })
+  },
 }
 
 module.exports = adminController

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,0 +1,29 @@
+const db = require('../models')
+const Tweet = db.Tweet
+const User = db.User
+const Reply = db.Reply
+
+const adminController = {
+
+  getTweets: (req, res) => {
+    // 看見站內所有的推播
+    Tweet.findAll({
+      include: [User, Reply],
+      order: [['createdAt', 'DESC']]
+    })
+      .then(tweets => {
+        tweets = tweets.map(tweet => ({
+          ...tweet.dataValues,
+          description: tweet.dataValues.description.substring(0, 50),
+          // 可以直接在清單上快覽推播回覆內容前 50 個字
+          Replies: tweet.dataValues.Replies.map(reply => ({
+            ...reply.dataValues,
+            comment: reply.dataValues.comment.substring(0, 50),
+          }))
+        }))
+        return res.render('admin/tweets', { tweets })
+      })
+  },
+}
+
+module.exports = adminController

--- a/routes/index.js
+++ b/routes/index.js
@@ -30,6 +30,8 @@ router.get('/', authenticated, (req, res) => res.redirect('/tweets'))
 router.get('/admin', authenticatedAdmin, (req, res) => res.redirect('/admin/tweets'))
 router.get('/admin/tweets', authenticatedAdmin, adminController.getTweets)
 router.delete('/admin/tweets/:id', authenticatedAdmin, adminController.deleteTweet)
+router.get('/admin/users', authenticatedAdmin, adminController.getUsers)
+router.put('/admin/users/:id', authenticatedAdmin, adminController.putUser)
 
 router.get('/signup', userController.signUpPage)
 router.post('/signup', userController.signUp)

--- a/routes/index.js
+++ b/routes/index.js
@@ -29,6 +29,7 @@ router.get('/', authenticated, (req, res) => res.redirect('/tweets'))
 
 router.get('/admin', authenticatedAdmin, (req, res) => res.redirect('/admin/tweets'))
 router.get('/admin/tweets', authenticatedAdmin, adminController.getTweets)
+router.delete('/admin/tweets/:id', authenticatedAdmin, adminController.deleteTweet)
 
 router.get('/signup', userController.signUpPage)
 router.post('/signup', userController.signUp)

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,8 @@
 const express = require('express')
 const router = express.Router()
-const helpers = require('../_helpers');
+const helpers = require('../_helpers')
 
+const adminController = require('../controllers/adminController.js')
 const userController = require('../controllers/userController.js')
 
 const passport = require('../config/passport')
@@ -14,9 +15,20 @@ const authenticated = (req, res, next) => {
   res.redirect('/signin')
 }
 
+const authenticatedAdmin = (req, res, next) => {
+  if (helpers.ensureAuthenticated(req)) {
+    if (helpers.getUser(req).role === 'admin') { return next() }
+    return res.redirect('/')
+  }
+  res.redirect('/signin')
+}
+
 // use helpers.getUser(req) to replace req.user
 // use helpers.ensureAuthenticated(req) to replace req.isAuthenticated()
-router.get('/', authenticated, (req, res) => res.render('tweets'))
+router.get('/', authenticated, (req, res) => res.redirect('/tweets'))
+
+router.get('/admin', authenticatedAdmin, (req, res) => res.redirect('/admin/tweets'))
+router.get('/admin/tweets', authenticatedAdmin, adminController.getTweets)
 
 router.get('/signup', userController.signUpPage)
 router.post('/signup', userController.signUp)

--- a/views/admin/tweets.handlebars
+++ b/views/admin/tweets.handlebars
@@ -1,0 +1,42 @@
+<h1>Simple Twitter後台</h1>
+
+<a href='/admin/tweets'>Tweets</a> |
+<a href='/admin/users'>Users</a>
+
+<br />
+<br />
+
+<table class="table">
+  <thead class="thead-dark">
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">User</th>
+      <th scope="col">Tweet</th>
+      <th scope="col">#</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each tweets}}
+    <tr>
+      <th scope="row">{{this.id}}</th>
+      <td>{{this.User.name}}</td>
+      <td>{{this.description}}</td>
+      <td>
+        {{#each this.Replies}}
+        <p>{{this.comment}}</p>
+        {{/each}}
+      </td>
+      <td>
+        <button type="button" class="btn btn-link">
+          <a href="/tweets/{{this.id}}">
+            Show
+          </a>
+        </button>
+        <form action="/admin/tweets/{{this.id}}?_method=DELETE" method="POST" style="display: inline;">
+          <button type="submit" class="btn btn-link">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {{/each}}
+  </tbody>
+</table>

--- a/views/admin/users.handlebars
+++ b/views/admin/users.handlebars
@@ -1,0 +1,54 @@
+<h1>Simple Twitter後台</h1>
+
+<a href='/admin/tweets'>Tweets</a> |
+<a href='/admin/users'>Users</a>
+
+<br />
+<br />
+
+<table class="table">
+  <thead class="thead-dark">
+    <tr>
+      <th scope="col">Email</th>
+      <th scope="col">Name</th>
+      <th scope="col">Role</th>
+      <th scope="col">#</th>
+      <th scope="col">推播數量</th>
+      <th scope="col">關注人數</th>
+      <th scope="col">跟隨者人數</th>
+      <th scope="col">推播被 like 的數量</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each users}}
+    <tr>
+      <th scope="row">{{this.email}}</th>
+      <td>{{this.name}}</td>
+      <td>{{this.role}}</td>
+      <td>
+        {{#ifCond this.role 'admin'}}
+        <form action="/admin/users/{{this.id}}?_method=PUT" method="POST">
+          <button type="submit" class="btn btn-link">set as user</button>
+        </form>
+        {{else}}
+        <form action="/admin/users/{{this.id}}?_method=PUT" method="POST">
+          <button type="submit" class="btn btn-link">set as admin</button>
+        </form>
+        {{/ifCond}}
+      </td>
+      <td>
+        {{this.TweetsCount}}
+      </td>
+      <td>
+        {{this.Followings.length}}
+      </td>
+      <td>
+        {{this.Followers.length}}
+      </td>
+      <td>
+        {{this.LikesCount}}
+      </td>
+    </tr>
+    {{/each}}
+  </tbody>
+</table>


### PR DESCRIPTION
**Create adminController and admin/tweets page. Add getTweets and authenticationAdmin**
- 新增adminController 和後台Tweets page
- 新增getTweets功能（管理員能看見站內所有推播，並可直接在清單上快覽推播回覆內容前 50 個字）
- 新增authenticationAdmin，確認為管理員身分才能進入後台
- 新增admin/tweets為後台首頁

**Add deleteTweet feature**
- 管理員能刪除其他使用者的推文

**Add getUsers and putUser feature and admin/users page**
- 新增後台 Users page
- getUsers (管理者可以瀏覽站內所有的使用者清單，清單的資訊包括：使用者社群活躍數據，包括推播數量、關注人數、跟隨者人數、推播被 like 的數量 (清單預設按推播文數排序))
- putUser (管理員能修改使用者身分為admin/user)

**待補**
- 後台前段介面等前台的出來後，再統一修改為一致風格，目前先以能將功能做出來為主
- 管理者登入網站後，能夠經由瀏覽列進入後台頁面 (只有管理員能看見後台入口)-->等navbar前端確定後再補加

請幫我看一下～